### PR TITLE
Bugfix for windows not playing well with hashes

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -30,6 +30,7 @@ var utils = {
 
   downloadCSVFile: function downloadCSVFile(csvContent, name){
     var encodedUri = encodeURI(csvContent);
+    encodedUri = encodedUri.replace('#', '%23');
     var link = document.createElement("a");
     var d = new Date();
     var timestamp = d.getTime();


### PR DESCRIPTION
Windows doesn't like hashes in URLs, so to fix this I'm just going
to do the lazy thing of replacing '#' with '%23'. I probaby should
look for a better fix, but I'm deplying this fix first.